### PR TITLE
Clean up install_islet() function

### DIFF
--- a/islet/provision.sh
+++ b/islet/provision.sh
@@ -49,20 +49,19 @@ apt-get install -y cowsay git make
 }
 
 install_islet(){
+	
+git clone http://github.com/jonschipp/islet
+
 if ! [ -d islet ]
-then
-	git clone http://github.com/jonschipp/islet
-	if [ -d islet ]
-	then
-		cd islet
-		make install-docker && ./configure && make logo &&
-		make install && make user-config && make security-config
-		make install-brolive-config
-		#make install-sample-distros
-		#make install-sample-nsm
-	else
-		die "Clone of islet repo failed"
-	fi
+then 
+	die "Clone of islet repo failed"
+else
+	cd islet
+	make install-docker && ./configure && make logo &&
+	make install && make user-config && make security-config
+	make install-brolive-config
+	#make install-sample-distros
+	#make install-sample-nsm
 fi
 }
 


### PR DESCRIPTION
The if statement makes more sense like this.  Unless I'm missing something it should be safe to assume that the islet directory will not exist when provisioning a fresh system, so it now tries to run the clone and if the directory doesn't exist after that it dies.
